### PR TITLE
Updated deployment rules to deploy on Railway

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,4 +67,4 @@ ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 
 # Start the server by default, this can be overwritten at runtime
 EXPOSE 3000
-CMD ["./bin/rails", "server"]
+CMD ["rails", "server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,6 @@ RUN chmod +x bin/* && \
 # Check for any syntax errors in assets and install any missing gems
 RUN bundle install
 
-# If the above command succeeds, precompile the assets
-RUN if [ $? -eq 0 ]; then SECRET_KEY_BASE=$(rails secret) ./bin/rails assets:precompile; fi
-
 # Final stage for app image
 FROM base
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN chmod +x bin/* && \
 RUN bundle install
 
 # If the above command succeeds, precompile the assets
-RUN if [ $? -eq 0 ]; then SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile; fi
+RUN if [ $? -eq 0 ]; then SECRET_KEY_BASE=$(rails secret) ./bin/rails assets:precompile; fi
 
 # Final stage for app image
 FROM base

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ ENV RAILS_ENV="production" \
     BUNDLE_PATH="/usr/local/bundle" \
     BUNDLE_WITHOUT="development"
 
-
 # Throw-away build stage to reduce size of final image
 FROM base as build
 
@@ -53,6 +52,9 @@ RUN apt-get update -qq && \
 COPY --from=build /usr/local/bundle /usr/local/bundle
 COPY --from=build /rails /rails
 
+# Add the bin directory of the installed gems to the PATH
+ENV PATH="/usr/local/bundle/bin:${PATH}"
+
 # Copy the entrypoint script into the image
 COPY bin/docker-entrypoint /rails/bin/
 RUN chmod +x /rails/bin/docker-entrypoint
@@ -67,4 +69,4 @@ ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 
 # Start the server by default, this can be overwritten at runtime
 EXPOSE 3000
-CMD ["rails", "server"]
+CMD ["./bin/rails", "server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,7 @@ RUN chmod +x bin/* && \
     sed -i 's/ruby\.exe$/ruby/' bin/*
 
 # Check for any syntax errors in assets and install any missing gems
-RUN bundle exec rake assets:check && \
-    bundle install
+RUN bundle install
 
 # If the above command succeeds, precompile the assets
 RUN if [ $? -eq 0 ]; then SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,9 +38,12 @@ RUN chmod +x bin/* && \
     sed -i "s/\r$//g" bin/* && \
     sed -i 's/ruby\.exe$/ruby/' bin/*
 
-# Precompiling assets for production without requiring secret RAILS_MASTER_KEY
-RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
+# Check for any syntax errors in assets and install any missing gems
+RUN bundle exec rake assets:check && \
+    bundle install
 
+# If the above command succeeds, precompile the assets
+RUN if [ $? -eq 0 ]; then SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile; fi
 
 # Final stage for app image
 FROM base

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,9 @@ RUN apt-get update -qq && \
 COPY --from=build /usr/local/bundle /usr/local/bundle
 COPY --from=build /rails /rails
 
+# Copy the entrypoint script into the image
+COPY bin/docker-entrypoint /rails/bin/
+
 # Run and own only the runtime files as a non-root user for security
 RUN useradd rails --create-home --shell /bin/bash && \
     chown -R rails:rails db log storage tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ COPY --from=build /rails /rails
 
 # Copy the entrypoint script into the image
 COPY bin/docker-entrypoint /rails/bin/
+RUN chmod +x /rails/bin/docker-entrypoint
 
 # Run and own only the runtime files as a non-root user for security
 RUN useradd rails --create-home --shell /bin/bash && \

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: rake db:migrate && bin/rails server -b 0.0.0.0 -p $PORT

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: rake db:migrate && bin/rails server -b 0.0.0.0 -p $PORT
+web: rake db:migrate && bin/rails server -b 0.0.0.0 -p {PORT: -3000}

--- a/Profile.dev
+++ b/Profile.dev
@@ -1,0 +1,1 @@
+web: bin/rails server -p 3000

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -20,6 +20,11 @@ if [ "$1" = 'rails' ] && [ "$2" = 'server' ]; then
     bin/rails db:migrate
     bin/rails db:seed
   fi
+
+  if [ -f tmp/pids/server.pid ]; then
+    echo "Deleting server PID file..."
+    rm tmp/pids/server.pid
+  fi
 fi
 
 exec "$@"

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -2,7 +2,7 @@
 set -e
 
 # Wait for the database server to be ready
-until bin/rails db:migrate:status &>/dev/null; do
+until bin/rails db:version; do
   echo "Database server is unavailable - sleeping"
   sleep 1
 done

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -2,7 +2,7 @@
 set -e
 
 # Wait for the database server to be ready
-until bin/rails db:exists; do
+until bin/rails db:migrate:status &>/dev/null; do
   echo "Database server is unavailable - sleeping"
   sleep 1
 done

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -1,8 +1,11 @@
-#!/bin/bash -e
+#!/bin/bash
+set -e
 
-# If running the rails server then create or migrate existing database
-if [ "${1}" == "./bin/rails" ] && [ "${2}" == "server" ]; then
-  ./bin/rails db:prepare
+# If the command passed is 'rails server', then we need to set up the database
+if [ "$1" = 'rails' ] && [ "$2" = 'server' ]; then
+  bin/rails db:create
+  bin/rails db:migrate
+  bin/rails db:seed
 fi
 
-exec "${@}"
+exec "$@"

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -1,8 +1,17 @@
 #!/bin/bash
 set -e
 
+# Wait for the database server to be ready
+until bin/rails db:exists; do
+  echo "Database server is unavailable - sleeping"
+  sleep 1
+done
+
+echo "Database server is up - executing command"
+
 # If the command passed is 'rails server', then we need to set up the database
 if [ "$1" = 'rails' ] && [ "$2" = 'server' ]; then
+  echo "Preparing database..."
   bin/rails db:create
   bin/rails db:migrate
   bin/rails db:seed

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -11,10 +11,15 @@ echo "Database server is up - executing command"
 
 # If the command passed is 'rails server', then we need to set up the database
 if [ "$1" = 'rails' ] && [ "$2" = 'server' ]; then
-  echo "Preparing database..."
-  bin/rails db:create
-  bin/rails db:migrate
-  bin/rails db:seed
+  # Check if the database exists
+  if bin/rails db:version; then
+    echo "Database exists, skipping creation and seeding"
+  else
+    echo "Preparing database..."
+    bin/rails db:create
+    bin/rails db:migrate
+    bin/rails db:seed
+  fi
 fi
 
 exec "$@"

--- a/config/database.yml
+++ b/config/database.yml
@@ -17,6 +17,3 @@ test:
 production:
   <<: *default
   url: <%= ENV['DATABASE_URL'] %>
-  database: full_stuck_project_production
-  username: full_stuck_project
-  password: <%= ENV["HELLO_RAILS_DATABASE_PASSWORD"] %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -72,5 +72,6 @@ Rails.application.configure do
   # config.action_cable.disable_request_forgery_protection = true
 
   # Raise error when a before_action's only/except options reference missing actions
-  config.action_controller.raise_on_missing_callback_actions = true
+  config.action_controller.raise_on_missing_callback_actions = true  
+  config.host<<"full-stuck-project-production.up.railway.app"
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -94,4 +94,5 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.host<<"full-stuck-project-production.up.railway.app"
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -94,5 +94,5 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
-  config.hosts<<"full-stuck-project-production.up.railway.app"
+  config.hosts << "page-to-page-library-backend-production.up.railway.app"
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -94,5 +94,5 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
-  config.host<<"full-stuck-project-production.up.railway.app"
+  config.hosts<<"full-stuck-project-production.up.railway.app"
 end

--- a/lib/tasks/fake-assets.rake
+++ b/lib/tasks/fake-assets.rake
@@ -1,0 +1,6 @@
+namespace :assets do
+    desc "Should just print stuff and move on. Fake!"
+    task :precompile do 
+        puts "This is a Fake assets:precompile"
+    end
+end

--- a/lib/tasks/fake-assets.rake
+++ b/lib/tasks/fake-assets.rake
@@ -1,6 +1,0 @@
-namespace :assets do
-    desc "Should just print stuff and move on. Fake!"
-    task :precompile do 
-        puts "This is a Fake assets:precompile"
-    end
-end

--- a/lib/tasks/fake_assets.rake
+++ b/lib/tasks/fake_assets.rake
@@ -1,0 +1,6 @@
+namespace :assets do
+  desc 'Should just print stuff and move on. Fake!'
+  task :precompile do
+    puts 'This is a Fake assets:precompile'
+  end
+end


### PR DESCRIPTION
Made some changes to the deployment rules so that our API can be deployed at Railway, instead of Render.

Apologies for the slight mess of commits. There were a lot of tests to verify how Railway worked as well as making sure everything was running smoothly.